### PR TITLE
Add support for all common SD CS pins

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,15 @@
 #------------------------------------------------------------------
 # Makefile for stand-alone MMC boot strap loader
 #------------------------------------------------------------------
-# Change these three defs for the target device
+# Change these defs for the target device
 
-MCU_TARGET  = atmega1284p # Target device to be used (32K or lager)
-BOOT_ADR    = 0x1F000	# Boot loader start address [byte] NOT [word] as in http://eleccelerator.com/fusecalc/fusecalc.php?chip=atmega1284p
-F_CPU       = 16000000	# CPU clock frequency [Hz]
-USE_LED     = 0	# Debug with two (defined in asmfunc.S)
-USE_UART    = 0	# Debug on Serial. 0 ... deactivate or divider of http://wormfood.net/avrbaudcalc.php for baud rate!
+MCU_TARGET    = atmega1284p # Target device to be used (32K or larger)
+BOOT_ADR      = 0x1F000 # Boot loader start address [byte] NOT [word] as in http://eleccelerator.com/fusecalc/fusecalc.php?chip=atmega1284p
+F_CPU         = 16000000  # CPU clock frequency [Hz]
+CS_PIN        = 4 # Arduino pin connected to SD CS. Supported values: 4, 8, 10, 53.
+VARIANT_1284P = 0 # ATmega1284P variant: 0=avr_developers/standard, 1=bobuino, 2=sleepingbeauty
+USE_LED       = 0 # Debug with two (defined in asmfunc.S)
+USE_UART      = 0 # Debug on Serial. 0 ... deactivate or divider of http://wormfood.net/avrbaudcalc.php for baud rate!
 #------------------------------------------------------------------
 ifeq ($(strip $(USE_UART)),0)
 CSRC        = main.c pff/src/pff.c diskio.c
@@ -18,7 +20,7 @@ endif
 TARGET      = avr_boot
 ASRC        = asmfunc.S
 OPTIMIZE    = -Os -mcall-prologues -ffunction-sections -fdata-sections
-DEFS        = -DBOOT_ADR=$(BOOT_ADR) -DF_CPU=$(F_CPU) -DUSE_LED=$(USE_LED) -DUSE_UART=$(USE_UART)
+DEFS        = -DBOOT_ADR=$(BOOT_ADR) -DF_CPU=$(F_CPU) -DUSE_LED=$(USE_LED) -DUSE_UART=$(USE_UART) -DCS_PIN=$(CS_PIN) -DVARIANT_1284P=$(VARIANT_1284P)
 LIBS        =
 DEBUG       = dwarf-2
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ This is with avr-gcc and avrdude under linux with an Atmega1284p and avrIsp mkII
 - adapt Makefile
   - MCU_TARGET: Your atmegaXXX
   - BOOT_ADR: in bytes not words!
-  - F_CPU:  CPU Frequency
+  - F_CPU: CPU Frequency
+  - CS_PIN: Arduino pin that the SD CS pin is connected to. Supported values are: 4, 8, 10, 53.
+  - VARIANT_1284P: ATmega1284P variant: 0=avr_developers/standard, 1=bobuino, 2=sleepingbeauty
   - USE_LED: For debugging 0...deactivate or 1...active
   - USE_UART: For debugging 0...deactivate or divider (UBRR) for baudate see http://wormfood.net/avrbaudcalc.php
 - update asmfunc.S pins with those of your atmega if not listed

--- a/asmfunc.S
+++ b/asmfunc.S
@@ -3,7 +3,7 @@
 ;---------------------------------------------------------------------------;
 ; Hardware dependent macros to be modified //do this in Makefile
 
-; ALL Pins given es Port (A,B,C,...) plus number
+; ALL Pins given as Port (A,B,C,...) plus number
 
 ; LED Pins
 #define	DDR_SS	_SFR_IO_ADDR(DDRD), 5	// SS pin (PIN, PORT)
@@ -13,11 +13,47 @@
 #define PORT_PW _SFR_IO_ADDR(PORTD), 6
 
 
-
 ;SD CARD PINS
-#if defined(__AVR_ATmega2560__) || defined(__AVR_ATmega1280__) || defined(__AVR_ATmega32U4__)
+#if defined(__AVR_ATmega2560__) || defined(__AVR_ATmega1280__)
+#if CS_PIN == 4
+#define	DDR_CS	_SFR_IO_ADDR(DDRG), 5	// MMC CS SS pin (DDR, PORT)
+#define	PORT_CS	_SFR_IO_ADDR(PORTG), 5
+#elif CS_PIN == 8
+#define	DDR_CS	_SFR_IO_ADDR(DDRH), 5	// MMC CS SS pin (DDR, PORT)
+#define	PORT_CS	_SFR_IO_ADDR(PORTH), 5
+#elif CS_PIN == 10
+#define	DDR_CS	_SFR_IO_ADDR(DDRB), 4	// MMC CS SS pin (DDR, PORT)
+#define	PORT_CS	_SFR_IO_ADDR(PORTB), 4
+#elif CS_PIN == 53
 #define	DDR_CS	_SFR_IO_ADDR(DDRB), 0	// MMC CS SS pin (DDR, PORT)
 #define	PORT_CS	_SFR_IO_ADDR(PORTB), 0
+#else	//CS_PIN
+#error CS_PIN not configured for this MCU
+#endif	//CS_PIN
+
+#define	DDR_DI	_SFR_IO_ADDR(DDRB), 2	// MMC DI MOSI pin (DDR, PORT)
+#define	PORT_DI	_SFR_IO_ADDR(PORTB), 2
+
+#define	PIN_DO	_SFR_IO_ADDR(PINB), 3	// MMC DO MISO pin (PIN, PORT)
+#define	PORT_DO	_SFR_IO_ADDR(PORTB), 3
+
+#define	DDR_CK	_SFR_IO_ADDR(DDRB), 1	// MMC SCLK pin (DDR, PORT)
+#define	PORT_CK	_SFR_IO_ADDR(PORTB), 1
+
+
+#elif defined(__AVR_ATmega32U4__)
+#if CS_PIN == 4
+#define	DDR_CS	_SFR_IO_ADDR(DDRD), 4	// MMC CS SS pin (DDR, PORT)
+#define	PORT_CS	_SFR_IO_ADDR(PORTD), 4
+#elif CS_PIN == 8
+#define	DDR_CS	_SFR_IO_ADDR(DDRB), 4	// MMC CS SS pin (DDR, PORT)
+#define	PORT_CS	_SFR_IO_ADDR(PORTB), 4
+#elif CS_PIN == 10
+#define	DDR_CS	_SFR_IO_ADDR(DDRB), 6	// MMC CS SS pin (DDR, PORT)
+#define	PORT_CS	_SFR_IO_ADDR(PORTB), 6
+#else	//CS_PIN
+#error CS_PIN not configured for this MCU
+#endif	//CS_PIN
 
 #define	DDR_DI	_SFR_IO_ADDR(DDRB), 2	// MMC DI MOSI pin (DDR, PORT)
 #define	PORT_DI	_SFR_IO_ADDR(PORTB), 2
@@ -30,8 +66,42 @@
 
 
 #elif defined(__AVR_ATmega1284__) || defined(__AVR_ATmega1284P__) || defined(__AVR_ATmega644__)  || defined(__AVR_ATmega644A__) || defined(__AVR_ATmega644P__)  || defined(__AVR_ATmega644PA__)
+#if VARIANT_1284P < 0 || VARIANT_1284P > 2
+#error Invalid VARIANT_1284P value
+#endif	//VARIANT_1284P < 0 || VARIANT_1284P > 2
+#if CS_PIN == 4
+#if VARIANT_1284P == 0  //avr_developers/standard
 #define	DDR_CS	_SFR_IO_ADDR(DDRB), 4	// MMC CS SS pin (DDR, PORT)
 #define	PORT_CS	_SFR_IO_ADDR(PORTB), 4
+#else	//VARIANT_1284P == 0
+//bobuino/sleepingbeauty
+#define	DDR_CS	_SFR_IO_ADDR(DDRB), 0	// MMC CS SS pin (DDR, PORT)
+#define	PORT_CS	_SFR_IO_ADDR(PORTB), 0
+#endif	//VARIANT_1284P == 0
+#elif CS_PIN == 8
+#if VARIANT_1284P == 0  //avr_developers/standard
+#define	DDR_CS	_SFR_IO_ADDR(DDRD), 0	// MMC CS SS pin (DDR, PORT)
+#define	PORT_CS	_SFR_IO_ADDR(PORTD), 0
+#elif VARIANT_1284P == 1  //bobuino
+#define	DDR_CS	_SFR_IO_ADDR(DDRD), 5	// MMC CS SS pin (DDR, PORT)
+#define	PORT_CS	_SFR_IO_ADDR(PORTD), 5
+#else	/VARIANT_1284P == 0
+//sleepingbeauty
+#define	DDR_CS	_SFR_IO_ADDR(DDRD), 6	// MMC CS SS pin (DDR, PORT)
+#define	PORT_CS	_SFR_IO_ADDR(PORTD), 6
+#endif	//VARIANT_1284P == 0
+#elif CS_PIN == 10
+#if VARIANT_1284P == 0	//avr_developers/standard
+#define	DDR_CS	_SFR_IO_ADDR(DDRD), 2	// MMC CS SS pin (DDR, PORT)
+#define	PORT_CS	_SFR_IO_ADDR(PORTD), 2
+#else	//VARIANT_1284P == 0
+//bobuino/sleepingbeauty
+#define	DDR_CS	_SFR_IO_ADDR(DDRB), 4	// MMC CS SS pin (DDR, PORT)
+#define	PORT_CS	_SFR_IO_ADDR(PORTB), 4
+#endif	//VARIANT_1284P == 0
+#else	//CS_PIN
+#error CS_PIN not configured for this MCU
+#endif	//CS_PIN
 
 #define	DDR_DI	_SFR_IO_ADDR(DDRB), 5	// MMC DI MOSI pin (DDR, PORT)
 #define	PORT_DI	_SFR_IO_ADDR(PORTB), 5
@@ -43,10 +113,19 @@
 #define	PORT_CK	_SFR_IO_ADDR(PORTB), 7
 
 
-
 #elif defined(__AVR_ATmega328__) || defined(__AVR_ATmega328P__)
+#if CS_PIN == 4
+#define	DDR_CS	_SFR_IO_ADDR(DDRD), 4	// MMC CS SS pin (DDR, PORT)
+#define	PORT_CS	_SFR_IO_ADDR(PORTD), 4
+#elif CS_PIN == 8
+#define	DDR_CS	_SFR_IO_ADDR(DDRB), 0	// MMC CS SS pin (DDR, PORT)
+#define	PORT_CS	_SFR_IO_ADDR(PORTB), 0
+#elif CS_PIN == 10
 #define	DDR_CS	_SFR_IO_ADDR(DDRB), 2	// MMC CS SS pin (DDR, PORT)
 #define	PORT_CS	_SFR_IO_ADDR(PORTB), 2
+#else	//CS_PIN
+#error CS_PIN not configured for this MCU
+#endif	//CS_PIN
 
 #define	DDR_DI	_SFR_IO_ADDR(DDRB), 3	// MMC DI MOSI pin (DDR, PORT)
 #define	PORT_DI	_SFR_IO_ADDR(PORTB), 3
@@ -57,9 +136,11 @@
 #define	DDR_CK	_SFR_IO_ADDR(DDRB), 5	// MMC SCLK pin (DDR, PORT)
 #define	PORT_CK	_SFR_IO_ADDR(PORTB), 5
 
-#else
+
+#else	//defined(__AVR_ATmega2560__) || defined(__AVR_ATmega1280__)
 #error Processor not configured. You must modify asmfunc.S.
-#endif
+#endif	//defined(__AVR_ATmega2560__) || defined(__AVR_ATmega1280__)
+
 
 /*
 //sparkfun microsd


### PR DESCRIPTION
Adds support for SD card CS pins on Arduino pins 4, 8, and 10 for ATmega328P, ATmega32U4, ATmega1284P et. al.(for all 4 Mighty 1284P variants) and Arduino pins 4, 8, 10, and 53 on ATmega2560. ATmega2560 has not been tested due to avr_boot currently not working correctly for that MCU.