### PR TITLE
Deal with issues exposed/caused by Arduino AVR Boards 1.6.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ This bootloader loads a file from the SD card on startup. This documentation is 
 
 
 ## Installation
+**WARNING: avr_boot is not compatible with Arduino AVR Boards 1.6.12(included with Arduino IDE 1.6.10).**
+
 There are two options for installing **avr_boot** boards in the Arduino IDE:
 #### Boards Manager Installation(requires Arduino IDE version 1.6.4 or greater)
 - Open the Arduino IDE.

--- a/package_zevero_avr_boot_index.json
+++ b/package_zevero_avr_boot_index.json
@@ -26,18 +26,7 @@
             {"name": "ATmega32U4"},
             {"name": "ATmega1284P"}
           ],
-          "toolsDependencies": [
-            {
-              "packager": "arduino",
-              "name": "avr-gcc",
-              "version": "4.8.1-arduino5"
-            },
-            {
-              "packager": "arduino",
-              "name": "avrdude",
-              "version": "6.0.1-arduino5"
-            }
-          ]
+          "toolsDependencies": []
         }
       ],
       "tools": []


### PR DESCRIPTION
Removing toolsDependencies entries from package_zevero_avr_boot_index.json is required due to a bug in the Arduino IDE which causes the tool versions specified by avr_boot to be used by other platforms such as Arduino AVR Boards after Boards Manager installation of avr_boot(see
https://github.com/arduino/Arduino/issues/5168). An example of a specific issue caused by this is that Arduino AVR Boards 1.6.12  requires LTO support, which avr-gcc does not have. This will cause Arduino AVR Boards to no longer compile when the previous version of package_zevero_avr_boot_index.json was used to install avr_boot.

Removing the toolsDependencies entries causes avr_boot to use whatever tool versions were previously installed.

The disadvantages of this solution are:
- Breaks compatibility with the Eclipse Arduino plugin(see https://github.com/jantje/arduino-eclipse-plugin/issues/516), which requires these entries.
- Loss of control over the specific toolchain used.

There is an additional issue caused by the upgrade to avrdude 6.3.0-arduino2 in Arduino AVR Boards 1.6.12. avrdude's handling of unused fuse bits has changed since the previous version Arduino used(6.0.1-arduino5) which causes the ATmega328P extended_fuses value to fail verification(see https://github.com/arduino/Arduino/issues/5175) and the unlock_bits and lock_bits values to fail verification when used with Atmel AVRISP mkII and likely any other stk500v2 based programmer(see https://github.com/arduino/avrdude-build-script/issues/2). Fixing these issues while maintaining backwards compatibility with previous Arduino AVR Boards versions would be possible by adding an avrdude tool to avr_boot but the Arduino developers have decided to revert to the previous avrdude version on the soon to be released Arduino AVR Boards 1.6.13 and only upgrade to a new avrdude version once it has been modified to work with the traditional Arduino fuse values(see https://github.com/arduino/Arduino/pull/5021 and https://github.com/arduino/Arduino/pull/5202). This makes me think that the extra complexity of adding an avrdude tool is not worth the benefit of providing compatibility with a single buggy Arduino AVR Boards version and so have added a warning message to the installation instructions about the incompatibility. I've identified what needs to be done to add an avrdude tool and I'm willing to consider that alternative if maximum compatibility or the newer avrdude version is considered important. There is another issue caused by the avrdude 6.3.0-arduino2 build(https://github.com/arduino/Arduino/issues/5173) which may affect avr_boot if that version was added as a tool. So far I've been unable to reproduce this but if so it would negate any advantages gained by the addition of the new avrdude version as an avr_dude tool.