### PR TITLE
Support alternate register names

### DIFF
--- a/asmfunc.S
+++ b/asmfunc.S
@@ -337,6 +337,10 @@ xmit_spi:
 ;
 ; void flash_erase (DWORD flash_addr);
 
+#ifndef SPMCSR
+#define SPMCSR SPMCR
+#endif
+
 .global flash_erase
 .func flash_erase
 flash_erase:

--- a/main.c
+++ b/main.c
@@ -38,7 +38,14 @@
 
 const char filename[13] ="FIRMWARE.BIN\0"; 	// EDIT FILENAME HERE
 #include <avr/wdt.h> //Watchdog
-uint8_t mcusr_mirror __attribute__ ((section (".noinit")));void get_mcusr(void) __attribute__((naked)) __attribute__((section(".init3")));void get_mcusr(void){mcusr_mirror = MCUSR;MCUSR = 0;wdt_disable();}
+// The following code is recommended in http://avr-libc.nongnu.org/user-manual/group__avr__watchdog.html but is disabled for now because avr_boot doesn't currently do anything with mcusr_mirror so for now we will only reset MCUSR and disable WDT.
+//uint8_t mcusr_mirror __attribute__ ((section (".noinit")));void get_mcusr(void) __attribute__((naked)) __attribute__((section(".init3")));void get_mcusr(void){mcusr_mirror = MCUSR;MCUSR = 0;wdt_disable();}
+void disable_watchdog(void) __attribute__((naked)) __attribute__((section(".init3")));
+void disable_watchdog(void)
+{
+	MCUSR = 0;	//some MCUs require the watchdog reset flag to be cleared before WDT can be cleared
+	wdt_disable();	//immediately disable watchdog in case it was running in the application to avoid perpetual reset loop
+}
 #include <avr/io.h>
 #include <avr/pgmspace.h>
 #include <avr/eeprom.h>

--- a/main.c
+++ b/main.c
@@ -43,7 +43,11 @@ const char filename[13] ="FIRMWARE.BIN\0"; 	// EDIT FILENAME HERE
 void disable_watchdog(void) __attribute__((naked)) __attribute__((section(".init3")));
 void disable_watchdog(void)
 {
+#if defined(MCUCSR)
+	MCUCSR = ~(_BV(WDRF));	//Some MCUs require the watchdog reset flag to be cleared before WDT can be disabled. & operation is skipped to spare few bytes as bits in MCUSR can only be cleared.
+#else
 	MCUSR = ~(_BV(WDRF));	//Some MCUs require the watchdog reset flag to be cleared before WDT can be disabled. & operation is skipped to spare few bytes as bits in MCUSR can only be cleared.
+#endif
 	wdt_disable();	//immediately disable watchdog in case it was running in the application to avoid perpetual reset loop
 }
 #include <avr/io.h>

--- a/main.c
+++ b/main.c
@@ -43,7 +43,7 @@ const char filename[13] ="FIRMWARE.BIN\0"; 	// EDIT FILENAME HERE
 void disable_watchdog(void) __attribute__((naked)) __attribute__((section(".init3")));
 void disable_watchdog(void)
 {
-	MCUSR = 0;	//some MCUs require the watchdog reset flag to be cleared before WDT can be cleared
+	MCUSR = ~(_BV(WDRF));	//Some MCUs require the watchdog reset flag to be cleared before WDT can be disabled. & operation is skipped to spare few bytes as bits in MCUSR can only be cleared.
 	wdt_disable();	//immediately disable watchdog in case it was running in the application to avoid perpetual reset loop
 }
 #include <avr/io.h>


### PR DESCRIPTION
This allows avr_boot to compile for ATmega32/A, 64A, 128/A which have different register names.

I have tested this code on ATmega328P, ATmega32U4, and ATmega1284P.

I tried to break the changes into some logical parts to make it clear what was being done. Please let me know if you want any changes. I can squash them into the current commits of this pull request to keep the commit history clean.

Closes #14