### PR TITLE
Define SD CS pin using standard AVR register/bit notation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,9 @@
 MCU_TARGET    = atmega1284p # Target device to be used (32K or larger)
 BOOT_ADR      = 0x1F000 # Boot loader start address [byte] NOT [word] as in http://eleccelerator.com/fusecalc/fusecalc.php?chip=atmega1284p
 F_CPU         = 16000000  # CPU clock frequency [Hz] NOT critical: it just should be higher than the actual Hz 
-CS_PIN        = 4 # Arduino pin connected to SD CS. Supported values: 4, 8, 10, 53.
-VARIANT_1284P = 0 # ATmega1284P variant: 0=avr_developers/standard, 1=bobuino, 2=sleepingbeauty
+SD_CS_PORT    = PORTB # Data Register of the SD CS pin
+SD_CS_DDR     = DDRB # Data Direction Register of the SD CS pin
+SD_CS_BIT     = 4 # Bit of the SD CS pin
 USE_LED       = 0 # Debug with two (defined in asmfunc.S)
 USE_UART      = 0 # Debug on Serial. 0 ... deactivate or divider of http://wormfood.net/avrbaudcalc.php for baud rate!
 #------------------------------------------------------------------
@@ -20,7 +21,7 @@ endif
 TARGET      = avr_boot
 ASRC        = asmfunc.S
 OPTIMIZE    = -Os -mcall-prologues -ffunction-sections -fdata-sections
-DEFS        = -DBOOT_ADR=$(BOOT_ADR) -DF_CPU=$(F_CPU) -DUSE_LED=$(USE_LED) -DUSE_UART=$(USE_UART) -DCS_PIN=$(CS_PIN) -DVARIANT_1284P=$(VARIANT_1284P)
+DEFS        = -DBOOT_ADR=$(BOOT_ADR) -DF_CPU=$(F_CPU) -DUSE_LED=$(USE_LED) -DUSE_UART=$(USE_UART) -DSD_CS_PORT=$(SD_CS_PORT) -DSD_CS_DDR=$(SD_CS_DDR) -DSD_CS_BIT=$(SD_CS_BIT)
 LIBS        =
 DEBUG       = dwarf-2
 

--- a/README.md
+++ b/README.md
@@ -23,11 +23,12 @@ This is with avr-gcc and avrdude under linux with an Atmega1284p and AVRISP mkII
   - MCU_TARGET: Your atmegaXXX
   - BOOT_ADR: in bytes not words!
   - F_CPU: CPU Frequency (not critical. A higher value will work as well)
-  - CS_PIN: Arduino pin that the SD CS pin is connected to. Supported values are: 4, 8, 10, 53.
-  - VARIANT_1284P: ATmega1284P variant: 0=avr_developers/standard, 1=bobuino, 2=sleepingbeauty
+  - SD_CS_PORT: Data Register of the SD CS pin(see the datasheet for your microcontroller)
+  - SD_CS_DDR: Data Direction Register of the SD CS pin
+  - SD_CS_BIT: Bit of the SD CS pin
   - USE_LED: For debugging 0...deactivate or 1...active
   - USE_UART: For debugging 0...deactivate or divider (UBRR) for baudate see http://wormfood.net/avrbaudcalc.php
-- update asmfunc.S pins with those of your atmega if not listed
+- update spi_pins.h with the SPI pins of your microcontroller if not already defined
 - if using USE_LED adapt LED-pins in asmfunc.S
 - if you want to add FAT12 adapt pff/src/pffconfh.h (default ist FAT16 + FAT32)
 - if you want to support lower case filenames adapt pff/src/pffconfh.h (default is uppercase)

--- a/asmfunc.S
+++ b/asmfunc.S
@@ -2,6 +2,7 @@
 ; MMC hardware controls and Flash controls      (C)ChaN, 2010
 ;---------------------------------------------------------------------------;
 ; Hardware dependent macros to be modified //do this in Makefile
+#include "spi_pins.h"
 
 ; ALL Pins given as Port (A,B,C,...) plus number
 
@@ -12,163 +13,10 @@
 #define	DDR_PW	_SFR_IO_ADDR(DDRD), 6	// Power pin (PIN, PORT)
 #define PORT_PW _SFR_IO_ADDR(PORTD), 6
 
-
 ;SD CARD PINS
-#if defined(__AVR_ATmega2560__) || defined(__AVR_ATmega1280__)
-#if CS_PIN == 4
-#define	DDR_CS	_SFR_IO_ADDR(DDRG), 5	// MMC CS SS pin (DDR, PORT)
-#define	PORT_CS	_SFR_IO_ADDR(PORTG), 5
-#elif CS_PIN == 8
-#define	DDR_CS	_SFR_IO_ADDR(DDRH), 5	// MMC CS SS pin (DDR, PORT)
-#define	PORT_CS	_SFR_IO_ADDR(PORTH), 5
-#elif CS_PIN == 10
-#define	DDR_CS	_SFR_IO_ADDR(DDRB), 4	// MMC CS SS pin (DDR, PORT)
-#define	PORT_CS	_SFR_IO_ADDR(PORTB), 4
-#elif CS_PIN == 53
-#define	DDR_CS	_SFR_IO_ADDR(DDRB), 0	// MMC CS SS pin (DDR, PORT)
-#define	PORT_CS	_SFR_IO_ADDR(PORTB), 0
-#else	//CS_PIN
-#error CS_PIN not configured for this MCU
-#endif	//CS_PIN
+#define	DDR_CS	_SFR_IO_ADDR(SD_CS_DDR), SD_CS_BIT
+#define	PORT_CS	_SFR_IO_ADDR(SD_CS_PORT), SD_CS_BIT
 
-#define	DDR_DI	_SFR_IO_ADDR(DDRB), 2	// MMC DI MOSI pin (DDR, PORT)
-#define	PORT_DI	_SFR_IO_ADDR(PORTB), 2
-
-#define	PIN_DO	_SFR_IO_ADDR(PINB), 3	// MMC DO MISO pin (PIN, PORT)
-#define	PORT_DO	_SFR_IO_ADDR(PORTB), 3
-
-#define	DDR_CK	_SFR_IO_ADDR(DDRB), 1	// MMC SCLK pin (DDR, PORT)
-#define	PORT_CK	_SFR_IO_ADDR(PORTB), 1
-
-
-#elif defined(__AVR_ATmega32U4__)
-#if CS_PIN == 4
-#define	DDR_CS	_SFR_IO_ADDR(DDRD), 4	// MMC CS SS pin (DDR, PORT)
-#define	PORT_CS	_SFR_IO_ADDR(PORTD), 4
-#elif CS_PIN == 8
-#define	DDR_CS	_SFR_IO_ADDR(DDRB), 4	// MMC CS SS pin (DDR, PORT)
-#define	PORT_CS	_SFR_IO_ADDR(PORTB), 4
-#elif CS_PIN == 10
-#define	DDR_CS	_SFR_IO_ADDR(DDRB), 6	// MMC CS SS pin (DDR, PORT)
-#define	PORT_CS	_SFR_IO_ADDR(PORTB), 6
-#else	//CS_PIN
-#error CS_PIN not configured for this MCU
-#endif	//CS_PIN
-
-#define	DDR_DI	_SFR_IO_ADDR(DDRB), 2	// MMC DI MOSI pin (DDR, PORT)
-#define	PORT_DI	_SFR_IO_ADDR(PORTB), 2
-
-#define	PIN_DO	_SFR_IO_ADDR(PINB), 3	// MMC DO MISO pin (PIN, PORT)
-#define	PORT_DO	_SFR_IO_ADDR(PORTB), 3
-
-#define	DDR_CK	_SFR_IO_ADDR(DDRB), 1	// MMC SCLK pin (DDR, PORT)
-#define	PORT_CK	_SFR_IO_ADDR(PORTB), 1
-
-
-#elif defined(__AVR_ATmega1284__) || defined(__AVR_ATmega1284P__) || defined(__AVR_ATmega644__)  || defined(__AVR_ATmega644A__) || defined(__AVR_ATmega644P__)  || defined(__AVR_ATmega644PA__)
-#if VARIANT_1284P < 0 || VARIANT_1284P > 2
-#error Invalid VARIANT_1284P value
-#endif	//VARIANT_1284P < 0 || VARIANT_1284P > 2
-#if CS_PIN == 4
-#if VARIANT_1284P == 0  //avr_developers/standard
-#define	DDR_CS	_SFR_IO_ADDR(DDRB), 4	// MMC CS SS pin (DDR, PORT)
-#define	PORT_CS	_SFR_IO_ADDR(PORTB), 4
-#else	//VARIANT_1284P == 0
-//bobuino/sleepingbeauty
-#define	DDR_CS	_SFR_IO_ADDR(DDRB), 0	// MMC CS SS pin (DDR, PORT)
-#define	PORT_CS	_SFR_IO_ADDR(PORTB), 0
-#endif	//VARIANT_1284P == 0
-#elif CS_PIN == 8
-#if VARIANT_1284P == 0  //avr_developers/standard
-#define	DDR_CS	_SFR_IO_ADDR(DDRD), 0	// MMC CS SS pin (DDR, PORT)
-#define	PORT_CS	_SFR_IO_ADDR(PORTD), 0
-#elif VARIANT_1284P == 1  //bobuino
-#define	DDR_CS	_SFR_IO_ADDR(DDRD), 5	// MMC CS SS pin (DDR, PORT)
-#define	PORT_CS	_SFR_IO_ADDR(PORTD), 5
-#else	//VARIANT_1284P == 0
-//sleepingbeauty
-#define	DDR_CS	_SFR_IO_ADDR(DDRD), 6	// MMC CS SS pin (DDR, PORT)
-#define	PORT_CS	_SFR_IO_ADDR(PORTD), 6
-#endif	//VARIANT_1284P == 0
-#elif CS_PIN == 10
-#if VARIANT_1284P == 0	//avr_developers/standard
-#define	DDR_CS	_SFR_IO_ADDR(DDRD), 2	// MMC CS SS pin (DDR, PORT)
-#define	PORT_CS	_SFR_IO_ADDR(PORTD), 2
-#else	//VARIANT_1284P == 0
-//bobuino/sleepingbeauty
-#define	DDR_CS	_SFR_IO_ADDR(DDRB), 4	// MMC CS SS pin (DDR, PORT)
-#define	PORT_CS	_SFR_IO_ADDR(PORTB), 4
-#endif	//VARIANT_1284P == 0
-#else	//CS_PIN
-#error CS_PIN not configured for this MCU
-#endif	//CS_PIN
-
-#define	DDR_DI	_SFR_IO_ADDR(DDRB), 5	// MMC DI MOSI pin (DDR, PORT)
-#define	PORT_DI	_SFR_IO_ADDR(PORTB), 5
-
-#define	PIN_DO	_SFR_IO_ADDR(PINB), 6	// MMC DO MISO pin (PIN, PORT)
-#define	PORT_DO	_SFR_IO_ADDR(PORTB), 6
-
-#define	DDR_CK	_SFR_IO_ADDR(DDRB), 7	// MMC SCLK pin (DDR, PORT)
-#define	PORT_CK	_SFR_IO_ADDR(PORTB), 7
-
-
-#elif defined(__AVR_ATmega328__) || defined(__AVR_ATmega328P__)
-#if CS_PIN == 4
-#define	DDR_CS	_SFR_IO_ADDR(DDRD), 4	// MMC CS SS pin (DDR, PORT)
-#define	PORT_CS	_SFR_IO_ADDR(PORTD), 4
-#elif CS_PIN == 8
-#define	DDR_CS	_SFR_IO_ADDR(DDRB), 0	// MMC CS SS pin (DDR, PORT)
-#define	PORT_CS	_SFR_IO_ADDR(PORTB), 0
-#elif CS_PIN == 10
-#define	DDR_CS	_SFR_IO_ADDR(DDRB), 2	// MMC CS SS pin (DDR, PORT)
-#define	PORT_CS	_SFR_IO_ADDR(PORTB), 2
-#else	//CS_PIN
-#error CS_PIN not configured for this MCU
-#endif	//CS_PIN
-
-#define	DDR_DI	_SFR_IO_ADDR(DDRB), 3	// MMC DI MOSI pin (DDR, PORT)
-#define	PORT_DI	_SFR_IO_ADDR(PORTB), 3
-
-#define	PIN_DO	_SFR_IO_ADDR(PINB), 4	// MMC DO MISO pin (PIN, PORT)
-#define	PORT_DO	_SFR_IO_ADDR(PORTB), 4
-
-#define	DDR_CK	_SFR_IO_ADDR(DDRB), 5	// MMC SCLK pin (DDR, PORT)
-#define	PORT_CK	_SFR_IO_ADDR(PORTB), 5
-
-
-#else	//defined(__AVR_ATmega2560__) || defined(__AVR_ATmega1280__)
-#error Processor not configured. You must modify asmfunc.S.
-#endif	//defined(__AVR_ATmega2560__) || defined(__AVR_ATmega1280__)
-
-
-/*
-//sparkfun microsd
-//#define	DDR_CS	_SFR_IO_ADDR(DDRB), 0	// MMC CS pin (DDR, PORT)
-//#define	PORT_CS	_SFR_IO_ADDR(PORTB), 0
-// i2GPS
-//#define	DDR_CS	_SFR_IO_ADDR(DDRB), 2	// MMC CS pin (DDR, PORT)
-//#define	PORT_CS	_SFR_IO_ADDR(PORTB), 2
-
-// Arduino Ethernet
-#define	DDR_CS	_SFR_IO_ADDR(DDRB), 2	// MMC CS SS pin (DDR, PORT)
-#define	PORT_CS	_SFR_IO_ADDR(PORTB), 2
-
-#define	DDR_DI	_SFR_IO_ADDR(DDRB), 3	// MMC DI MOSI pin (DDR, PORT)
-#define	PORT_DI	_SFR_IO_ADDR(PORTB), 3
-
-#define	PIN_DO	_SFR_IO_ADDR(PINB), 4	// MMC DO MISO pin (PIN, PORT)
-#define	PORT_DO	_SFR_IO_ADDR(PORTB), 4
-
-#define	DDR_CK	_SFR_IO_ADDR(DDRB), 5	// MMC SCLK pin (DDR, PORT)
-#define	PORT_CK	_SFR_IO_ADDR(PORTB), 5
-
-#define	DDR_SS	_SFR_IO_ADDR(DDRD), 6	// SS pin (PIN, PORT)
-#define PORT_SS _SFR_IO_ADDR(PORTD), 6
-
-#define	DDR_PW	_SFR_IO_ADDR(DDRD), 7	// Power pin (PIN, PORT)
-#define PORT_PW _SFR_IO_ADDR(PORTD), 7
-*/
 ;---------------------------------------------------------------------------;
 .nolist
 #include <avr/io.h>

--- a/spi_pins.h
+++ b/spi_pins.h
@@ -1,0 +1,51 @@
+// MOSI, MISO, and SCK pin definitions for all standard ATmega microcontrollers
+#ifndef SPI_PINS_H
+#define SPI_PINS_H
+
+#if defined(__AVR_ATmega64__) || defined(__AVR_ATmega64A__) || defined(__AVR_ATmega64M1__) || defined(__AVR_ATmega128__) || defined(__AVR_ATmega128A__) || \
+defined(__AVR_ATmega640__) || defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__) || \
+defined(__AVR_ATmega1281__) || defined(__AVR_ATmega2561__) || \
+defined(__AVR_ATmega165__) || defined(__AVR_ATmega165A__) || defined(__AVR_ATmega165P__) || defined(__AVR_ATmega165PA__) || defined(__AVR_ATmega325__) ||defined(__AVR_ATmega325A__) || defined(__AVR_ATmega325P__) || defined(__AVR_ATmega325PA__) || defined(__AVR_ATmega645__) || defined(__AVR_ATmega645A__) || defined(__AVR_ATmega645P__) || \
+defined(__AVR_ATmega3250__) || defined(__AVR_ATmega3250A__) || defined(__AVR_ATmega3250P__) || defined(__AVR_ATmega3250PA__) || defined(__AVR_ATmega6450__) || defined(__AVR_ATmega6450A__) || defined(__AVR_ATmega6450P__) || \
+defined(__AVR_ATmega169__) || defined(__AVR_ATmega169A__) || defined(__AVR_ATmega169P__) || defined(__AVR_ATmega169PA__) || defined(__AVR_ATmega329__) || defined(__AVR_ATmega329A__) || defined(__AVR_ATmega329P__) || defined(__AVR_ATmega329PA__) || defined(__AVR_ATmega3290__) || defined(__AVR_ATmega3290A__) || defined(__AVR_ATmega3290P__)  || defined(__AVR_ATmega3290PA__) || defined(__AVR_ATmega649__) || defined(__AVR_ATmega649A__) || defined(__AVR_ATmega649P__) || defined(__AVR_ATmega6490__) || defined(__AVR_ATmega6490A__) || defined(__AVR_ATmega6490P__) || \
+defined(__AVR_ATmega8U2__) || defined(__AVR_ATmega16U2__) || defined(__AVR_ATmega16U4__) || defined(__AVR_ATmega32U2__) || defined(__AVR_ATmega32U4__) || defined(__AVR_ATmega32U6__)
+#define	DDR_DI	_SFR_IO_ADDR(DDRB), 2	//MMC DI MOSI pin (DDR, PORT)
+#define	PORT_DI	_SFR_IO_ADDR(PORTB), 2
+
+#define	PIN_DO	_SFR_IO_ADDR(PINB), 3	//MMC DO MISO pin (PIN, PORT)
+#define	PORT_DO	_SFR_IO_ADDR(PORTB), 3
+
+#define	DDR_CK	_SFR_IO_ADDR(DDRB), 1	//MMC SCK pin (DDR, PORT)
+#define	PORT_CK	_SFR_IO_ADDR(PORTB), 1
+
+
+#elif defined(__AVR_ATmega8__) || defined(__AVR_ATmega8A__) || defined(__AVR_ATmega48__) || defined(__AVR_ATmega48A__) || defined(__AVR_ATmega48P__) || defined(__AVR_ATmega48PA__) || defined(__AVR_ATmega48PB__) || defined(__AVR_ATmega88__) || defined(__AVR_ATmega88A__) || defined(__AVR_ATmega88P__) || defined(__AVR_ATmega88PA__) || defined(__AVR_ATmega88PB__) || defined(__AVR_ATmega168__) || defined(__AVR_ATmega168A__) || defined(__AVR_ATmega168P__) || defined(__AVR_ATmega168PA__) || defined(__AVR_ATmega168PB__) ||defined(__AVR_ATmega328__) || defined(__AVR_ATmega328P__) || defined(__AVR_ATmega328PB__)
+#define	DDR_DI	_SFR_IO_ADDR(DDRB), 3
+#define	PORT_DI	_SFR_IO_ADDR(PORTB), 3
+
+#define	PIN_DO	_SFR_IO_ADDR(PINB), 4
+#define	PORT_DO	_SFR_IO_ADDR(PORTB), 4
+
+#define	DDR_CK	_SFR_IO_ADDR(DDRB), 5
+#define	PORT_CK	_SFR_IO_ADDR(PORTB), 5
+
+
+#elif defined(__AVR_ATmega16__) || defined(__AVR_ATmega16A__) || defined(__AVR_ATmega16M1__) || defined(__AVR_ATmega32__) || defined(__AVR_ATmega32A__) || defined(__AVR_ATmega32M1__) || \
+defined(__AVR_ATmega161__) || defined(__AVR_ATmega162__) || defined(__AVR_ATmega163__) || \
+defined(__AVR_ATmega164A__) || defined(__AVR_ATmega164P__) || defined(__AVR_ATmega164PA__) || defined(__AVR_ATmega323__) || defined(__AVR_ATmega324A__) || defined(__AVR_ATmega324P__)  || defined(__AVR_ATmega324PA__) || defined(__AVR_ATmega324PB__) || defined(__AVR_ATmega324PA__) || defined(__AVR_ATmega644__) || defined(__AVR_ATmega644A__) || defined(__AVR_ATmega644P__) || defined(__AVR_ATmega644PA__) || defined(__AVR_ATmega1284__) || defined(__AVR_ATmega1284P__) || \
+defined(__AVR_ATmega8515__) || defined(__AVR_ATmega8535__)
+#define	DDR_DI	_SFR_IO_ADDR(DDRB), 5
+#define	PORT_DI	_SFR_IO_ADDR(PORTB), 5
+
+#define	PIN_DO	_SFR_IO_ADDR(PINB), 6
+#define	PORT_DO	_SFR_IO_ADDR(PORTB), 6
+
+#define	DDR_CK	_SFR_IO_ADDR(DDRB), 7
+#define	PORT_CK	_SFR_IO_ADDR(PORTB), 7
+
+
+#else
+#error SPI pins not defined for your processor. You must modify spi_pins.h
+#endif
+
+#endif	//SPI_PINS_H


### PR DESCRIPTION
As I've started wanting to add Arduino IDE support for new boards I realized that the previous system for SD CS pin definition I created is limiting. The problem is every time I want to add a new processor or variant I need to modify asmfunc.S, cluttering it up more and more.

### Pros:
- Any standard ATmega microcontroller can be built for without editing source code. If a part has not been defined they only need to add it to spi_pins.h
- Any SD CS pin can be built for. No longer limited to the ones I happened to have defined in asmfunc.S
- Cleaner bootloader source code
- Not Arduino specific - people using avr_boot may not even use Arduino boards or IDE and won't want to figure out the Arduino pin mapping for their MCU.
- Easier to add Arduino IDE support for new boards - I only need to modify the gh-pages branch
- The `VARIANT_1284P` name is no longer appropriate due to supporting new processors and variants
- The previous system didn't lend itself well to multiple processor families with variants

### Cons:
- Breaks makefile backwards compatibility due to the new parameters. Some breakage may have been desirable anyways due to the increasingly inappropriate name of `VARIANT_1284P`.
- Less easy for Arduino people to build the bootloader. They will now need to look up the pin mappings for their board. However, it's likely that anyone this is a problem for will be using my IDE support files instead of building from source.

I have added SPI pin definitions for parts that don't have a large enough boot size for avr_boot because it was easier to just define pins for every ATmega instead of checking boot size for every one. 

Built without errors or new warnings for ATmega328/P, 32U4, 1284/P, 644/P/A/PA, 324P/A/PA, 32/A, 64/A, 128/A. Tested with ATmega328P, ATmega32U4, ATmega1284P.