### PR TITLE
Allow compiler options to be passed to the makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ DEBUG       = dwarf-2
 
 ASFLAGS     = -Wa,-adhlns=$(<:.S=.lst),-gstabs $(DEFS)
 ALL_ASFLAGS = -mmcu=$(MCU_TARGET) -I. -x assembler-with-cpp $(ASFLAGS)
-CFLAGS      = -g$(DEBUG) -Wall $(OPTIMIZE) -mmcu=$(MCU_TARGET) -std=c99 $(DEFS)
+CFLAGS      = -g$(DEBUG) -Wall $(OPTIMIZE) $(ADDED_CFLAGS) -mmcu=$(MCU_TARGET) -std=c99 $(DEFS)
 LDFLAGS     = -Wl,-Map,$(TARGET).map -Wl,--gc-sections -Wl,--section-start,.text=$(BOOT_ADR)
 OBJ         = $(CSRC:.c=.o) $(ASRC:.S=.o)
 


### PR DESCRIPTION
Added ADDED_CFLAGS variable to CFLAGS. For example, this allows me to use the command:

```
make MCU_TARGET=atmega1284p BOOT_ADR=0x1F000 F_CPU=16000000 SD_CS_PORT=PORTB SD_CS_DDR=DDRB SD_CS_BIT=4 USE_LED=0 USE_UART=0 ADDED_CFLAGS=-Wno-strict-aliasing TARGET=$(MCU_TARGET)_v0_cs4_$(F_CPU)L
```

To silence those annoying `dereferencing type-punned pointer will break strict-aliasing rules` warnings that make it hard for me to find any new warnings in the build log.
